### PR TITLE
expose glob options

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const PotMaker = require('./pot-maker');
 function setDefaultOptions (options) {
   const defaultOptions = {
     src: '**/*.php',
+    globOpts: {},
     destFile: 'translations.pot',
     commentKeyword: 'translators:',
     headers: {
@@ -162,7 +163,7 @@ function wpPot (options) {
   options = setDefaultOptions(options);
 
   // Find and sort file paths
-  const files = pathSort(matched.sync(options.src));
+  const files = pathSort(matched.sync(options.src, options.globOpts));
 
   // Parse files
   for (const file of files) {

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,10 @@ wpPot({
   Description: Glob or globs to match files
   Type: `string|array`
   Default: `**/*.php`
+- `globOpts`
+  Description: [node-glob options](https://github.com/isaacs/node-glob#options) object to be passed through.
+  Type: `Object`
+  Default: `{}`
 - `team`
   Description: Name and email address of the translation team (ex: `Team <team@example.com> `).
   Type: `string`


### PR DESCRIPTION
In my use I have a process that runs wp-pot in various different repos and rebuilds the pots for each.  All the other tools I have integrated for build have node-glob's options exposed, which I rely on for some of the pattern logic.  It would be really helpful if this could be exposed in the configs as well, which would provide a whole lot more flexibility to how wp-pot can be used.  For me I would be able to pass the same configs in and have one flow for my build. Currently I have to run a separate pot generation process from inside each repo to get the pots to all work and format properly.

wp-pot uses [matched](https://github.com/jonschlinkert/matched#usage) and this module exposes the  options for [node-glob](https://github.com/isaacs/node-glob#options) and passes them through.

This PR just exposes the option via the configs, and doesn't add any defaults other than what are already set internally.

